### PR TITLE
Clab v15 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Arista Validated design with cEOS-lab
 
+![lab-version](https://img.shields.io/github/v/release/arista-netdevops-community/avd-cEOS-Lab?color=brightgreen&logo=appveyor&style=for-the-badge)
+![cEOS-AVD](https://img.shields.io/badge/AVD-cEOS-brightgreen?logo=appveyor&style=for-the-badge)
+
 - [Overview](#overview)
 - [Installation](#installation)
     - [Requirements](#requirements)

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Clone the repository and ensure to have the required libraries and software inst
 - Python 3.6.8 or above
 - ansible 2.10.0 or above
 - arista.avd ansible collection (latest)
-- containerlab=1.14.4 (compatible)
-  - containerlab=1.15 (not compatible, required changes to be added in next release)
+- containerlab=0.14.4 (last supported release [`v1.1.2`](https://github.com/arista-netdevops-community/avd-cEOS-Lab/releases))
+- containerlab=0.15 ( release [`v2.0.0`](https://github.com/arista-netdevops-community/avd-cEOS-Lab/releases) and above )
 - arista.avd requirements
 - docker
 - Arista cEOS-Lab image
@@ -46,7 +46,7 @@ For containerlab installation please refer to the [official](https://containerla
 
 For Python3, docker and ansible installation please refer to the installation guides based on the host OS.
 
-*NOTE* :warning: Currently the containerlab topology files in this repository are not containerlab=1.15 compatible.
+**NOTE** :warning: Containerlab topology definitions have changed starting v0.15 - [`Release Notes`](https://containerlab.srlinux.dev/rn/0.15/). Latest release of this repository is containerlab v0.15 compatible. For older containerlab compatible syntax download [`v1.1.2`](https://github.com/arista-netdevops-community/avd-cEOS-Lab/releases)
 
 ### Installing Arista cEOS-Lab image
 
@@ -98,6 +98,8 @@ Alternatively you can use cEOS container as a host, or any other linux based con
 
 ### cEOS containerlab template
 
+**NOTE** :warning: This is no longer required starting containerlab v0.15. The v2.0.0 and above releases of this repository includes this template in the `topology.yaml` itself.
+
 Replace the containerlab cEOS default template with the `ceos.cfg.tpl` file from this repository.
 
 ```shell
@@ -113,7 +115,7 @@ This is to ensure the containers by default come up with:
 2. MGMT vrf for management connectivity
 3. eAPI enabled
 
-***NOTE*** If the default template is not replaced with the one from this repository, then for the intial AVD config replace you will observe a timeout error.
+**NOTE** For containerlab version less than v0.15, If the default template is not replaced with the one from this repository, then for the intial AVD config replace you will observe a timeout error.
 
 ## AWS AMI
 

--- a/ceos_lab_template/ceos.cfg.tpl
+++ b/ceos_lab_template/ceos.cfg.tpl
@@ -8,8 +8,8 @@ vrf instance MGMT
 interface Management0
    description oob_management
    vrf MGMT
-{{ if .MgmtIPv4Address }}ip address {{ .MgmtIPv4Address }}/{{.MgmtIPv4PrefixLength}}{{end}}
-{{ if .MgmtIPv6Address }}ipv6 address {{ .MgmtIPv6Address }}/{{.MgmtIPv6PrefixLength}}{{end}}
+{{ if .MgmtIPv4Address }}   ip address {{ .MgmtIPv4Address }}/{{ .MgmtIPv4PrefixLength }}{{end}}
+{{ if .MgmtIPv6Address }}   ipv6 address {{ .MgmtIPv6Address }}/{{ .MgmtIPv6PrefixLength }}{{end}}
 !
 management api gnmi
    transport grpc default

--- a/labs/evpn/avd_asym_irb/topology.yaml
+++ b/labs/evpn/avd_asym_irb/topology.yaml
@@ -1,52 +1,48 @@
 name: avdasymirb
 
 topology:
+  kinds:
+    ceos:
+      startup-config: ../../../ceos_lab_template/ceos.cfg.tpl
+      image: ceosimage:4.26.1F
+    linux:
+      image: alpine-host
   nodes:
     spine1:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.2
     spine2:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.3
     leaf1a:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.4
     leaf1b:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.5
     leaf2a:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.6
     leaf2b:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.7
     client1:
       kind: linux
-      image: alpine-host
       mgmt_ipv4: 172.100.100.8
       env:
         TMODE: lacp
     client2:
       kind: linux
-      image: alpine-host
       mgmt_ipv4: 172.100.100.9
       env:
         TMODE: lacp
     client3:
       kind: linux
-      image: alpine-host
       mgmt_ipv4: 172.100.100.10
       env:
         TMODE: lacp
     client4:
       kind: linux
-      image: alpine-host
       mgmt_ipv4: 172.100.100.11
       env:
         TMODE: lacp

--- a/labs/evpn/avd_central_any_gw/topology.yaml
+++ b/labs/evpn/avd_central_any_gw/topology.yaml
@@ -1,56 +1,51 @@
 name: avdcentralgw
 
 topology:
+  kinds:
+    ceos:
+      startup-config: ../../../ceos_lab_template/ceos.cfg.tpl
+      image: ceosimage:4.26.1F
+    linux:
+      image: alpine-host
   nodes:
     spine1:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.2
     spine2:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.3
     leaf1a:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.4
     leaf1b:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.5
     leaf2a:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.6
     leaf3a:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.7
     leaf3b:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.8
     client1:
       kind: linux
-      image: alpine-host
       mgmt_ipv4: 172.100.100.9
       env:
         TMODE: lacp
     client2:
       kind: linux
-      image: alpine-host
       mgmt_ipv4: 172.100.100.10
       env:
         TMODE: lacp
     client3:
       kind: linux
-      image: alpine-host
       mgmt_ipv4: 172.100.100.11
       env:
         TMODE: lacp
     client4:
       kind: linux
-      image: alpine-host
       mgmt_ipv4: 172.100.100.12
       env:
         TMODE: lacp

--- a/labs/evpn/avd_sym_irb/topology.yaml
+++ b/labs/evpn/avd_sym_irb/topology.yaml
@@ -1,60 +1,54 @@
 name: avdirb
 
 topology:
+  kinds:
+    ceos:
+      startup-config: ../../../ceos_lab_template/ceos.cfg.tpl
+      image: ceosimage:4.26.1F
+    linux:
+      image: alpine-host
   nodes:
     spine1:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.2
     spine2:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.3
     leaf1a:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.4
     leaf1b:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.5
     svc2a:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.6
     svc2b:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.7
     l2leaf2a:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.8
     l2leaf2b:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.9
     client1:
       kind: linux
-      image: alpine-host
       mgmt_ipv4: 172.100.100.10
       env:
         TMODE: lacp
     client2:
       kind: linux
-      image: alpine-host
       mgmt_ipv4: 172.100.100.11
       env:
         TMODE: lacp
     client3:
       kind: linux
-      image: alpine-host
       mgmt_ipv4: 172.100.100.12
       env:
         TMODE: lacp
     client4:
       kind: linux
-      image: alpine-host
       mgmt_ipv4: 172.100.100.13
       env:
         TMODE: lacp

--- a/labs/evpn/avd_sym_irb_ibgp/topology.yaml
+++ b/labs/evpn/avd_sym_irb_ibgp/topology.yaml
@@ -1,52 +1,48 @@
 name: avdirb
 
 topology:
+  kinds:
+    ceos:
+      startup-config: ../../../ceos_lab_template/ceos.cfg.tpl
+      image: ceosimage:4.26.1F
+    linux:
+      image: alpine-host
   nodes:
     spine1:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.2
     spine2:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.3
     leaf1a:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.4
     leaf1b:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.5
     leaf2a:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.6
     leaf2b:
       kind: ceos
-      image: ceosimage:4.26.1F
       mgmt_ipv4: 172.100.100.7
     client1:
       kind: linux
-      image: alpine-host
       mgmt_ipv4: 172.100.100.8
       env:
         TMODE: lacp
     client2:
       kind: linux
-      image: alpine-host
       mgmt_ipv4: 172.100.100.9
       env:
         TMODE: lacp
     client3:
       kind: linux
-      image: alpine-host
       mgmt_ipv4: 172.100.100.10
       env:
         TMODE: lacp
     client4:
       kind: linux
-      image: alpine-host
       mgmt_ipv4: 172.100.100.11
       env:
         TMODE: lacp


### PR DESCRIPTION
Updated the `topology.yaml` files to support the new change in containerlab v0.15 release

https://containerlab.srlinux.dev/rn/0.15/

```css
This release adds a breaking change in the clab file schema. Starting from this release version, a path to a startup config file needs to be provided with startup-config key. Previously it was done with config key.

Use sed -i s/config:/startup-config:/g <topo-file> script to auto-substitute the values in the <topo-file> file.
```