### PR TITLE
Cipher suite eapi update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,26 +3,31 @@
 ![lab-version](https://img.shields.io/github/v/release/arista-netdevops-community/avd-cEOS-Lab?color=brightgreen&logo=appveyor&style=for-the-badge)
 ![cEOS-AVD](https://img.shields.io/badge/AVD-cEOS-brightgreen?logo=appveyor&style=for-the-badge)
 
-- [Overview](#overview)
-- [Installation](#installation)
+- [Arista Validated design with cEOS-lab](#arista-validated-design-with-ceos-lab)
+  - [Overview](#overview)
+  - [Installation](#installation)
     - [Requirements](#requirements)
+      - [AVD](#avd)
+      - [cEOS-Lab Deployment](#ceos-lab-deployment)
     - [Installing Arista cEOS-Lab image](#installing-arista-ceos-lab-image)
     - [Installing the alpine-host image](#installing-the-alpine-host-image)
     - [cEOS containerlab template](#ceos-containerlab-template)
-    - [AWS AMI](#aws-ami)
-- [Labs](#labs)
-- [Demo](#demo)
-- [Improvements](#improvements)
-  - [Alpine-host configuration](#alpine-host-configuration)
-    - [Bonding Configuration](#bonding-configuration)
-    - [L3 configuration](#l3-configuration)
+  - [AWS AMI](#aws-ami)
+  - [Labs](#labs)
+  - [Demo](#demo)
+    - [Using Makefile](#using-makefile)
+  - [Improvements](#improvements)
+    - [Alpine-host configuration](#alpine-host-configuration)
+      - [Bonding Configuration](#bonding-configuration)
+      - [Host L3 configuration](#host-l3-configuration)
+  - [Upcoming](#upcoming)
 
 ## Overview
 
 This repository contains ansible playbooks which allow the user to quickly:
 
 1. Deploy cEOS-Lab Leaf Spine topology using [containerlab](https://containerlab.dev/).
-2. Configure the Leaf Spine Fabric using Arista Ansible [AVD](https://avd.sh/en/latest/)
+2. Configure the Leaf Spine Fabric using Arista Ansible [AVD](https://avd.sh/en/stable/)
 
 The same AVD templates can also be used with vEOS-Lab and physical Lab switches with slight changes to lab files.
 
@@ -32,16 +37,21 @@ Clone the repository and ensure to have the required libraries and software inst
 
 ### Requirements
 
-- Python 3.6.8 or above
-- ansible-core from 2.11.3 to 2.12.x
+#### AVD
+
+- Python 3.8 or above
+- `ansible-core` from 2.11.3 to 2.12.x
 - arista.avd ansible collection (3.0.0 or above)
 - containerlab (0.15 or above)
 - arista.avd requirements
+
+#### cEOS-Lab Deployment
+
 - docker
 - Arista cEOS-Lab image (4.21.8M or above)
 - Alpine-host image (optional)
 
-For arista.avd installation please refer to the [official](https://avd.sh/en/latest/docs/installation/requirements.html) documenation.
+For arista.avd installation please refer to the [official](https://avd.sh/en/stable/docs/installation/requirements.html) documenation.
 
 For containerlab installation please refer to the [official](https://containerlab.dev/install/) documentation.
 
@@ -52,6 +62,8 @@ For Python3, docker and ansible installation please refer to the installation gu
 - Containerlab topology definitions have changed starting v0.15 - [`Release Notes`](https://containerlab.dev/rn/0.15/). Latest [`release`](https://github.com/arista-netdevops-community/avd-cEOS-Lab/releases) of this repository is containerlab v0.15 (and above) compatible. For older containerlab compatible syntax download [`v1.1.2`](https://github.com/arista-netdevops-community/avd-cEOS-Lab/releases)
 
 - arista.avd v3.0.0 contains breaking changes to data models [`Release Notes`](https://avd.sh/en/latest/docs/release-notes/3.x.x.html). Latest release of this repository is arista.avd v3.0.0 and above compatible. For older avd compatible syntax download older release. [`Releases`](https://github.com/arista-netdevops-community/avd-cEOS-Lab/releases)
+
+- Starting Python 3.10 the default SSL/TLS ciphers have been [updated](https://bugs.python.org/issue43998). Latest [`release`](https://github.com/arista-netdevops-community/avd-cEOS-Lab/releases) of this repository updates the cipher suite on EOS via a security profile applied to eAPI to be compatible with Python 3.10.
 
 ### Installing Arista cEOS-Lab image
 
@@ -103,9 +115,9 @@ Alternatively you can use cEOS-Lab container or any other linux based container 
 
 ### cEOS containerlab template
 
-**NOTE** :warning: This is no longer required starting containerlab v0.15. The v2.0.0 and above releases of this repository includes this template in the `topology.yaml` itself.
+**NOTE** :warning: <ins> This is no longer required starting containerlab v0.15.</ins> The v2.0.0 and above releases of this repository includes this template in the `topology.yaml` itself.
 
-For containerlab version less than v0.15, replace the containerlab cEOS default template with the `ceos.cfg.tpl` file from this repository. If the default template is not replaced with the one from this repository, then for the intial AVD config replace you will observe a timeout error.
+<ins>For containerlab version less than v0.15</ins>, replace the containerlab cEOS default template with the `ceos.cfg.tpl` file from this repository. If the default template is not replaced with the one from this repository, then for the intial AVD config replace you will observe a timeout error.
 
 ```shell
 ceos_lab_template
@@ -157,18 +169,19 @@ This Demo will deploy `avd_sym_irb` lab using containerlab and configure the Fab
 labs/evpn/avd_sym_irb
 ├── ansible.cfg
 ├── group_vars
-│   ├── AVD_LAB.yaml
-│   ├── DC1_FABRIC.yaml
-│   ├── DC1_L2_LEAFS.yaml
-│   ├── DC1_L3_LEAFS.yaml
-│   ├── DC1_SERVERS.yaml
-│   ├── DC1_SPINES.yaml
-│   └── DC1_TENANTS_NETWORKS.yaml
+│   ├── AVD_LAB.yaml
+│   ├── DC1_FABRIC.yaml
+│   ├── DC1_L2_LEAFS.yaml
+│   ├── DC1_L3_LEAFS.yaml
+│   ├── DC1_SERVERS.yaml
+│   ├── DC1_SPINES.yaml
+│   └── DC1_TENANTS_NETWORKS.yaml
 ├── host_l3_config
-│   └── l3_build.sh
+│   └── l3_build.sh
 ├── inventory.yaml
+├── Makefile
 ├── playbooks
-│   └── fabric-deploy-config.yaml
+│   └── fabric-deploy-config.yaml
 └── topology.yaml
 ```
 
@@ -278,6 +291,19 @@ Vxlan1 is up, line protocol is up (connected)
   MLAG Shared Router MAC is 021c.7313.b344
 ```
 
+### Using Makefile
+
+Each lab contains a `Makefile`, which simplifies the lab deployment steps using `make` command.
+
+To see available options
+
+```shell
+$ make help
+deploy                         Complete AVD & cEOS-Lab Deployment
+destroy                        Delete cEOS-Lab Deployment and AVD generated config and documentation
+help                           Display help message
+```
+
 ## Improvements
 
 ### Alpine-host configuration
@@ -320,9 +346,9 @@ Example:
 
 `TACTIVE` sets the active interface (ex. `eth1`) and the other interface (ex. `eth2`) will be automatically set to backup.
 
-#### L3 configuration
+#### Host L3 configuration
 
-Currently L3 configuration can be done either:
+Currently end host L3 configuration can be done either:
 
 - Using the `labs/evpn/avd_<lab>/host_l3_config/l3_build.sh`. The shell script contains the command to configure the VLAN, IP address, Gateway route on the alpine hosts.
   - If VLAN/SVIs (on the switch) are different from default templates please edit the `l3_build.sh` accordingly.
@@ -365,3 +391,7 @@ round-trip min/avg/max = 5.946/13.238/20.531 ms
 / $ arp -a
 ? (10.1.10.1) at 00:00:00:00:00:01 [ether]  on team0.110
 ```
+
+## Upcoming
+
+CVX VxLAN Lab

--- a/ceos_lab_template/ceos.cfg.tpl
+++ b/ceos_lab_template/ceos.cfg.tpl
@@ -11,8 +11,13 @@ interface Management0
 {{ if .MgmtIPv4Address }}   ip address {{ .MgmtIPv4Address }}/{{ .MgmtIPv4PrefixLength }}{{end}}
 {{ if .MgmtIPv6Address }}   ipv6 address {{ .MgmtIPv6Address }}/{{ .MgmtIPv6PrefixLength }}{{end}}
 !
+management security
+   ssl profile eAPI
+      cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+      certificate eAPI.crt key eAPI.key
+!
 management api http-commands
-   protocol https
+   protocol https ssl profile eAPI
    no shutdown
    !
    vrf MGMT

--- a/labs/evpn/avd_asym_irb/Makefile
+++ b/labs/evpn/avd_asym_irb/Makefile
@@ -1,0 +1,21 @@
+.PHONY: help
+help: ## Display help message
+	@grep -E '^[0-9a-zA-Z_-]+\.*[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: deploy
+deploy: ## Complete AVD & cEOS-Lab Deployment
+	@echo -e "\n############### \e[1;30;42mStarting cEOS-Lab topology\e[0m ###############\n"
+	@sudo containerlab deploy -t topology.yaml
+	@echo -e "\n############### \e[1;30;42mGenerating and deploying switch configuration\e[0m ###############\n"
+	@ansible-playbook playbooks/fabric-deploy-config.yaml --flush-cache
+	@echo -e "\n############### \e[1;30;42mConfiguring client nodes\e[0m ###############\n"
+	@bash host_l3_config/l3_build.sh
+	@echo -e "\n############### \e[1;30;42mcEOS-Lab Topology\e[0m ###############\n"
+	@sudo containerlab inspect -t topology.yaml
+	@echo -e "\n############### \e[1;30;42mcEOS-Lab Deployment Complete\e[0m ###############\n"
+
+.PHONY: destroy
+destroy: ## Delete cEOS-Lab Deployment and AVD generated config and documentation
+	@echo -e "\n############### \e[1;30;42mWiping nodes and deleting AVD configuration\e[0m ###############\n"
+	@sudo containerlab destroy -t topology.yaml --cleanup
+	@rm -rf .topology.yml.bak config_backup/ snapshots/ reports/ documentation/ intended/

--- a/labs/evpn/avd_asym_irb/group_vars/AVD_LAB.yaml
+++ b/labs/evpn/avd_asym_irb/group_vars/AVD_LAB.yaml
@@ -18,7 +18,8 @@ ntp:
 
 service_routing_protocols_model: multi-agent
 
-spanning_tree_mode: mstp
+spanning_tree:
+  mode: mstp
 
 ip_routing: true
 
@@ -27,11 +28,28 @@ mgmt_interface: Management0
 mgmt_gateway: 172.100.100.1
 
 # Management eAPI | Required for this Lab
-management_eapi:
-  enable_https: true
+custom_structured_configuration_management_api_http:
+  https_ssl_profile: eAPI
+
+# Management security required for SSL profile with strong ciphers
+#custom_structured_configuration_management_security:
+#  ssl_profiles:
+#    - name: eAPI
+#      certificate:
+#        file: eAPI.crt
+#        key: eAPI.key
+#      cipher_list: HIGH,!eNULL,!aNULL,!MD5,!ADH,!ANULL
+
+# cipher_list will be added in AVD rel 3.8.x till then using raw_eos_cli
+eos_cli: |
+  management security
+     ssl profile eAPI
+        cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+        certificate eAPI.crt key eAPI.key
 
 # Management GNMI | Optional
 #management_api_gnmi:
 #  enable_vrfs:
 #    MGMT:
 #  octa: true
+#  provider: eos-native

--- a/labs/evpn/avd_asym_irb/group_vars/DC1_FABRIC.yaml
+++ b/labs/evpn/avd_asym_irb/group_vars/DC1_FABRIC.yaml
@@ -28,7 +28,6 @@ spine:
         - distance bgp 20 200 200
         #- graceful-restart restart-time 300
         #- graceful-restart
-  leaf_as_range: 65101-65132
   nodes:
     DC1_SPINE1:
       id: 1
@@ -40,7 +39,6 @@ spine:
 l3leaf:
   defaults:
     platform: cEOS-LAB
-    bgp_as: 65100
     uplink_switches: [DC1_SPINE1, DC1_SPINE2]
     uplink_interfaces: [Ethernet1, Ethernet2]
     mlag_interfaces: [Ethernet3, Ethernet4]

--- a/labs/evpn/avd_asym_irb/topology.yaml
+++ b/labs/evpn/avd_asym_irb/topology.yaml
@@ -4,7 +4,11 @@ topology:
   kinds:
     ceos:
       startup-config: ../../../ceos_lab_template/ceos.cfg.tpl
-      image: ceosimage:4.27.3F
+      image: ceosimage:4.29.0.2F
+      exec:
+        - sleep 10
+        - FastCli -p 15 -c 'security pki key generate rsa 4096 eAPI.key'
+        - FastCli -p 15 -c 'security pki certificate generate self-signed eAPI.crt key eAPI.key generate rsa 4096 validity 30000 parameters common-name eAPI'
     linux:
       image: alpine-host
   nodes:

--- a/labs/evpn/avd_asym_multihoming/Makefile
+++ b/labs/evpn/avd_asym_multihoming/Makefile
@@ -1,0 +1,21 @@
+.PHONY: help
+help: ## Display help message
+	@grep -E '^[0-9a-zA-Z_-]+\.*[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: deploy
+deploy: ## Complete AVD & cEOS-Lab Deployment
+	@echo -e "\n############### \e[1;30;42mStarting cEOS-Lab topology\e[0m ###############\n"
+	@sudo containerlab deploy -t topology.yaml
+	@echo -e "\n############### \e[1;30;42mGenerating and deploying switch configuration\e[0m ###############\n"
+	@ansible-playbook playbooks/fabric-deploy-config.yaml --flush-cache
+	@echo -e "\n############### \e[1;30;42mConfiguring client nodes\e[0m ###############\n"
+	@bash host_l3_config/l3_build.sh
+	@echo -e "\n############### \e[1;30;42mcEOS-Lab Topology\e[0m ###############\n"
+	@sudo containerlab inspect -t topology.yaml
+	@echo -e "\n############### \e[1;30;42mcEOS-Lab Deployment Complete\e[0m ###############\n"
+
+.PHONY: destroy
+destroy: ## Delete cEOS-Lab Deployment and AVD generated config and documentation
+	@echo -e "\n############### \e[1;30;42mWiping nodes and deleting AVD configuration\e[0m ###############\n"
+	@sudo containerlab destroy -t topology.yaml --cleanup
+	@rm -rf .topology.yml.bak config_backup/ snapshots/ reports/ documentation/ intended/

--- a/labs/evpn/avd_asym_multihoming/group_vars/AVD_LAB.yaml
+++ b/labs/evpn/avd_asym_multihoming/group_vars/AVD_LAB.yaml
@@ -18,7 +18,8 @@ ntp:
 
 service_routing_protocols_model: multi-agent
 
-spanning_tree_mode: mstp
+spanning_tree:
+  mode: mstp
 
 ip_routing: true
 
@@ -27,11 +28,28 @@ mgmt_interface: Management0
 mgmt_gateway: 172.100.100.1
 
 # Management eAPI | Required for this Lab
-management_eapi:
-  enable_https: true
+custom_structured_configuration_management_api_http:
+  https_ssl_profile: eAPI
+
+# Management security required for SSL profile with strong ciphers
+#custom_structured_configuration_management_security:
+#  ssl_profiles:
+#    - name: eAPI
+#      certificate:
+#        file: eAPI.crt
+#        key: eAPI.key
+#      cipher_list: HIGH,!eNULL,!aNULL,!MD5,!ADH,!ANULL
+
+# cipher_list will be added in AVD rel 3.8.x till then using raw_eos_cli
+eos_cli: |
+  management security
+     ssl profile eAPI
+        cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+        certificate eAPI.crt key eAPI.key
 
 # Management GNMI | Optional
 #management_api_gnmi:
 #  enable_vrfs:
 #    MGMT:
 #  octa: true
+#  provider: eos-native

--- a/labs/evpn/avd_asym_multihoming/group_vars/DC1_FABRIC.yaml
+++ b/labs/evpn/avd_asym_multihoming/group_vars/DC1_FABRIC.yaml
@@ -26,7 +26,6 @@ spine:
       - distance bgp 20 200 200
       #- graceful-restart restart-time 300
       #- graceful-restart
-  leaf_as_range: 65101-65132
   nodes:
     DC1_SPINE1:
       id: 1

--- a/labs/evpn/avd_asym_multihoming/topology.yaml
+++ b/labs/evpn/avd_asym_multihoming/topology.yaml
@@ -4,7 +4,11 @@ topology:
   kinds:
     ceos:
       startup-config: ../../../ceos_lab_template/ceos.cfg.tpl
-      image: ceosimage:4.27.3F
+      image: ceosimage:4.29.0.2F
+      exec:
+        - sleep 10
+        - FastCli -p 15 -c 'security pki key generate rsa 4096 eAPI.key'
+        - FastCli -p 15 -c 'security pki certificate generate self-signed eAPI.crt key eAPI.key generate rsa 4096 validity 30000 parameters common-name eAPI'
     linux:
       image: alpine-host
   nodes:

--- a/labs/evpn/avd_central_any_gw/Makefile
+++ b/labs/evpn/avd_central_any_gw/Makefile
@@ -1,0 +1,21 @@
+.PHONY: help
+help: ## Display help message
+	@grep -E '^[0-9a-zA-Z_-]+\.*[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: deploy
+deploy: ## Complete AVD & cEOS-Lab Deployment
+	@echo -e "\n############### \e[1;30;42mStarting cEOS-Lab topology\e[0m ###############\n"
+	@sudo containerlab deploy -t topology.yaml
+	@echo -e "\n############### \e[1;30;42mGenerating and deploying switch configuration\e[0m ###############\n"
+	@ansible-playbook playbooks/fabric-deploy-config.yaml --flush-cache
+	@echo -e "\n############### \e[1;30;42mConfiguring client nodes\e[0m ###############\n"
+	@bash host_l3_config/l3_build.sh
+	@echo -e "\n############### \e[1;30;42mcEOS-Lab Topology\e[0m ###############\n"
+	@sudo containerlab inspect -t topology.yaml
+	@echo -e "\n############### \e[1;30;42mcEOS-Lab Deployment Complete\e[0m ###############\n"
+
+.PHONY: destroy
+destroy: ## Delete cEOS-Lab Deployment and AVD generated config and documentation
+	@echo -e "\n############### \e[1;30;42mWiping nodes and deleting AVD configuration\e[0m ###############\n"
+	@sudo containerlab destroy -t topology.yaml --cleanup
+	@rm -rf .topology.yml.bak config_backup/ snapshots/ reports/ documentation/ intended/

--- a/labs/evpn/avd_central_any_gw/group_vars/AVD_LAB.yaml
+++ b/labs/evpn/avd_central_any_gw/group_vars/AVD_LAB.yaml
@@ -18,7 +18,8 @@ ntp:
 
 service_routing_protocols_model: multi-agent
 
-spanning_tree_mode: mstp
+spanning_tree:
+  mode: mstp
 
 ip_routing: true
 
@@ -27,11 +28,28 @@ mgmt_interface: Management0
 mgmt_gateway: 172.100.100.1
 
 # Management eAPI | Required for this Lab
-management_eapi:
-  enable_https: true
+custom_structured_configuration_management_api_http:
+  https_ssl_profile: eAPI
+
+# Management security required for SSL profile with strong ciphers
+#custom_structured_configuration_management_security:
+#  ssl_profiles:
+#    - name: eAPI
+#      certificate:
+#        file: eAPI.crt
+#        key: eAPI.key
+#      cipher_list: HIGH,!eNULL,!aNULL,!MD5,!ADH,!ANULL
+
+# cipher_list will be added in AVD rel 3.8.x till then using raw_eos_cli
+eos_cli: |
+  management security
+     ssl profile eAPI
+        cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+        certificate eAPI.crt key eAPI.key
 
 # Management GNMI | Optional
 #management_api_gnmi:
 #  enable_vrfs:
 #    MGMT:
 #  octa: true
+#  provider: eos-native

--- a/labs/evpn/avd_central_any_gw/group_vars/DC1_FABRIC.yaml
+++ b/labs/evpn/avd_central_any_gw/group_vars/DC1_FABRIC.yaml
@@ -30,7 +30,6 @@ spine:
       - distance bgp 20 200 200
       #- graceful-restart restart-time 300
       #- graceful-restart
-  leaf_as_range: 65101-65132
   nodes:
     DC1_SPINE1:
       id: 1

--- a/labs/evpn/avd_central_any_gw/topology.yaml
+++ b/labs/evpn/avd_central_any_gw/topology.yaml
@@ -4,7 +4,11 @@ topology:
   kinds:
     ceos:
       startup-config: ../../../ceos_lab_template/ceos.cfg.tpl
-      image: ceosimage:4.27.3F
+      image: ceosimage:4.29.0.2F
+      exec:
+        - sleep 10
+        - FastCli -p 15 -c 'security pki key generate rsa 4096 eAPI.key'
+        - FastCli -p 15 -c 'security pki certificate generate self-signed eAPI.crt key eAPI.key generate rsa 4096 validity 30000 parameters common-name eAPI'
     linux:
       image: alpine-host
   nodes:

--- a/labs/evpn/avd_sym_irb/Makefile
+++ b/labs/evpn/avd_sym_irb/Makefile
@@ -1,0 +1,21 @@
+.PHONY: help
+help: ## Display help message
+	@grep -E '^[0-9a-zA-Z_-]+\.*[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: deploy
+deploy: ## Complete AVD & cEOS-Lab Deployment
+	@echo -e "\n############### \e[1;30;42mStarting cEOS-Lab topology\e[0m ###############\n"
+	@sudo containerlab deploy -t topology.yaml
+	@echo -e "\n############### \e[1;30;42mGenerating and deploying switch configuration\e[0m ###############\n"
+	@ansible-playbook playbooks/fabric-deploy-config.yaml --flush-cache
+	@echo -e "\n############### \e[1;30;42mConfiguring client nodes\e[0m ###############\n"
+	@bash host_l3_config/l3_build.sh
+	@echo -e "\n############### \e[1;30;42mcEOS-Lab Topology\e[0m ###############\n"
+	@sudo containerlab inspect -t topology.yaml
+	@echo -e "\n############### \e[1;30;42mcEOS-Lab Deployment Complete\e[0m ###############\n"
+
+.PHONY: destroy
+destroy: ## Delete cEOS-Lab Deployment and AVD generated config and documentation
+	@echo -e "\n############### \e[1;30;42mWiping nodes and deleting AVD configuration\e[0m ###############\n"
+	@sudo containerlab destroy -t topology.yaml --cleanup
+	@rm -rf .topology.yml.bak config_backup/ snapshots/ reports/ documentation/ intended/

--- a/labs/evpn/avd_sym_irb/group_vars/AVD_LAB.yaml
+++ b/labs/evpn/avd_sym_irb/group_vars/AVD_LAB.yaml
@@ -18,7 +18,8 @@ ntp:
 
 service_routing_protocols_model: multi-agent
 
-spanning_tree_mode: mstp
+spanning_tree:
+  mode: mstp
 
 ip_routing: true
 
@@ -27,11 +28,28 @@ mgmt_interface: Management0
 mgmt_gateway: 172.100.100.1
 
 # Management eAPI | Required for this Lab
-management_eapi:
-  enable_https: true
+custom_structured_configuration_management_api_http:
+  https_ssl_profile: eAPI
+
+# Management security required for SSL profile with strong ciphers
+#custom_structured_configuration_management_security:
+#  ssl_profiles:
+#    - name: eAPI
+#      certificate:
+#        file: eAPI.crt
+#        key: eAPI.key
+#      cipher_list: HIGH,!eNULL,!aNULL,!MD5,!ADH,!ANULL
+
+# cipher_list will be added in AVD rel 3.8.x till then using raw_eos_cli
+eos_cli: |
+  management security
+     ssl profile eAPI
+        cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+        certificate eAPI.crt key eAPI.key
 
 # Management GNMI | Optional
 #management_api_gnmi:
 #  enable_vrfs:
 #    MGMT:
 #  octa: true
+#  provider: eos-native

--- a/labs/evpn/avd_sym_irb/group_vars/DC1_FABRIC.yaml
+++ b/labs/evpn/avd_sym_irb/group_vars/DC1_FABRIC.yaml
@@ -28,7 +28,6 @@ spine:
       - distance bgp 20 200 200
       #- graceful-restart restart-time 300
       #- graceful-restart
-  leaf_as_range: 65101-65132
   nodes:
     DC1_SPINE1:
       id: 1

--- a/labs/evpn/avd_sym_irb/topology.yaml
+++ b/labs/evpn/avd_sym_irb/topology.yaml
@@ -4,7 +4,11 @@ topology:
   kinds:
     ceos:
       startup-config: ../../../ceos_lab_template/ceos.cfg.tpl
-      image: ceosimage:4.27.3F
+      image: ceosimage:4.29.0.2F
+      exec:
+        - sleep 10
+        - FastCli -p 15 -c 'security pki key generate rsa 4096 eAPI.key'
+        - FastCli -p 15 -c 'security pki certificate generate self-signed eAPI.crt key eAPI.key generate rsa 4096 validity 30000 parameters common-name eAPI'
     linux:
       image: alpine-host
   nodes:

--- a/labs/evpn/avd_sym_irb_ibgp/Makefile
+++ b/labs/evpn/avd_sym_irb_ibgp/Makefile
@@ -1,0 +1,21 @@
+.PHONY: help
+help: ## Display help message
+	@grep -E '^[0-9a-zA-Z_-]+\.*[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: deploy
+deploy: ## Complete AVD & cEOS-Lab Deployment
+	@echo -e "\n############### \e[1;30;42mStarting cEOS-Lab topology\e[0m ###############\n"
+	@sudo containerlab deploy -t topology.yaml
+	@echo -e "\n############### \e[1;30;42mGenerating and deploying switch configuration\e[0m ###############\n"
+	@ansible-playbook playbooks/fabric-deploy-config.yaml --flush-cache
+	@echo -e "\n############### \e[1;30;42mConfiguring client nodes\e[0m ###############\n"
+	@bash host_l3_config/l3_build.sh
+	@echo -e "\n############### \e[1;30;42mcEOS-Lab Topology\e[0m ###############\n"
+	@sudo containerlab inspect -t topology.yaml
+	@echo -e "\n############### \e[1;30;42mcEOS-Lab Deployment Complete\e[0m ###############\n"
+
+.PHONY: destroy
+destroy: ## Delete cEOS-Lab Deployment and AVD generated config and documentation
+	@echo -e "\n############### \e[1;30;42mWiping nodes and deleting AVD configuration\e[0m ###############\n"
+	@sudo containerlab destroy -t topology.yaml --cleanup
+	@rm -rf .topology.yml.bak config_backup/ snapshots/ reports/ documentation/ intended/

--- a/labs/evpn/avd_sym_irb_ibgp/group_vars/AVD_LAB.yaml
+++ b/labs/evpn/avd_sym_irb_ibgp/group_vars/AVD_LAB.yaml
@@ -18,7 +18,8 @@ ntp:
 
 service_routing_protocols_model: multi-agent
 
-spanning_tree_mode: mstp
+spanning_tree:
+  mode: mstp
 
 ip_routing: true
 
@@ -27,11 +28,28 @@ mgmt_interface: Management0
 mgmt_gateway: 172.100.100.1
 
 # Management eAPI | Required for this Lab
-management_eapi:
-  enable_https: true
+custom_structured_configuration_management_api_http:
+  https_ssl_profile: eAPI
+
+# Management security required for SSL profile with strong ciphers
+#custom_structured_configuration_management_security:
+#  ssl_profiles:
+#    - name: eAPI
+#      certificate:
+#        file: eAPI.crt
+#        key: eAPI.key
+#      cipher_list: HIGH,!eNULL,!aNULL,!MD5,!ADH,!ANULL
+
+# cipher_list will be added in AVD rel 3.8.x till then using raw_eos_cli
+eos_cli: |
+  management security
+     ssl profile eAPI
+        cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+        certificate eAPI.crt key eAPI.key
 
 # Management GNMI | Optional
 #management_api_gnmi:
 #  enable_vrfs:
 #    MGMT:
 #  octa: true
+#  provider: eos-native

--- a/labs/evpn/avd_sym_irb_ibgp/topology.yaml
+++ b/labs/evpn/avd_sym_irb_ibgp/topology.yaml
@@ -4,7 +4,11 @@ topology:
   kinds:
     ceos:
       startup-config: ../../../ceos_lab_template/ceos.cfg.tpl
-      image: ceosimage:4.27.3F
+      image: ceosimage:4.29.0.2F
+      exec:
+        - sleep 10
+        - FastCli -p 15 -c 'security pki key generate rsa 4096 eAPI.key'
+        - FastCli -p 15 -c 'security pki certificate generate self-signed eAPI.crt key eAPI.key generate rsa 4096 validity 30000 parameters common-name eAPI'
     linux:
       image: alpine-host
   nodes:

--- a/labs/evpn/avd_sym_sa_multihoming/Makefile
+++ b/labs/evpn/avd_sym_sa_multihoming/Makefile
@@ -1,0 +1,21 @@
+.PHONY: help
+help: ## Display help message
+	@grep -E '^[0-9a-zA-Z_-]+\.*[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: deploy
+deploy: ## Complete AVD & cEOS-Lab Deployment
+	@echo -e "\n############### \e[1;30;42mStarting cEOS-Lab topology\e[0m ###############\n"
+	@sudo containerlab deploy -t topology.yaml
+	@echo -e "\n############### \e[1;30;42mGenerating and deploying switch configuration\e[0m ###############\n"
+	@ansible-playbook playbooks/fabric-deploy-config.yaml --flush-cache
+	@echo -e "\n############### \e[1;30;42mConfiguring client nodes\e[0m ###############\n"
+	@bash host_l3_config/l3_build.sh
+	@echo -e "\n############### \e[1;30;42mcEOS-Lab Topology\e[0m ###############\n"
+	@sudo containerlab inspect -t topology.yaml
+	@echo -e "\n############### \e[1;30;42mcEOS-Lab Deployment Complete\e[0m ###############\n"
+
+.PHONY: destroy
+destroy: ## Delete cEOS-Lab Deployment and AVD generated config and documentation
+	@echo -e "\n############### \e[1;30;42mWiping nodes and deleting AVD configuration\e[0m ###############\n"
+	@sudo containerlab destroy -t topology.yaml --cleanup
+	@rm -rf .topology.yml.bak config_backup/ snapshots/ reports/ documentation/ intended/

--- a/labs/evpn/avd_sym_sa_multihoming/group_vars/AVD_LAB.yaml
+++ b/labs/evpn/avd_sym_sa_multihoming/group_vars/AVD_LAB.yaml
@@ -18,7 +18,8 @@ ntp:
 
 service_routing_protocols_model: multi-agent
 
-spanning_tree_mode: mstp
+spanning_tree:
+  mode: mstp
 
 ip_routing: true
 
@@ -27,11 +28,28 @@ mgmt_interface: Management0
 mgmt_gateway: 172.100.100.1
 
 # Management eAPI | Required for this Lab
-management_eapi:
-  enable_https: true
+custom_structured_configuration_management_api_http:
+  https_ssl_profile: eAPI
+
+# Management security required for SSL profile with strong ciphers
+#custom_structured_configuration_management_security:
+#  ssl_profiles:
+#    - name: eAPI
+#      certificate:
+#        file: eAPI.crt
+#        key: eAPI.key
+#      cipher_list: HIGH,!eNULL,!aNULL,!MD5,!ADH,!ANULL
+
+# cipher_list will be added in AVD rel 3.8.x till then using raw_eos_cli
+eos_cli: |
+  management security
+     ssl profile eAPI
+        cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+        certificate eAPI.crt key eAPI.key
 
 # Management GNMI | Optional
 #management_api_gnmi:
 #  enable_vrfs:
 #    MGMT:
 #  octa: true
+#  provider: eos-native

--- a/labs/evpn/avd_sym_sa_multihoming/group_vars/AVD_LAB.yaml
+++ b/labs/evpn/avd_sym_sa_multihoming/group_vars/AVD_LAB.yaml
@@ -40,13 +40,6 @@ custom_structured_configuration_management_api_http:
 #        key: eAPI.key
 #      cipher_list: HIGH,!eNULL,!aNULL,!MD5,!ADH,!ANULL
 
-# cipher_list will be added in AVD rel 3.8.x till then using raw_eos_cli
-eos_cli: |
-  management security
-     ssl profile eAPI
-        cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
-        certificate eAPI.crt key eAPI.key
-
 # Management GNMI | Optional
 #management_api_gnmi:
 #  enable_vrfs:

--- a/labs/evpn/avd_sym_sa_multihoming/group_vars/DC1_FABRIC.yaml
+++ b/labs/evpn/avd_sym_sa_multihoming/group_vars/DC1_FABRIC.yaml
@@ -26,7 +26,6 @@ spine:
       - distance bgp 20 200 200
       #- graceful-restart restart-time 300
       #- graceful-restart
-  leaf_as_range: 65101-65132
   nodes:
     DC1_SPINE1:
       id: 1

--- a/labs/evpn/avd_sym_sa_multihoming/group_vars/DC1_FABRIC.yaml
+++ b/labs/evpn/avd_sym_sa_multihoming/group_vars/DC1_FABRIC.yaml
@@ -88,6 +88,11 @@ l3leaf:
             vlan 111
               designated-forwarder election preference rule low
             !
+            management security
+               ssl profile eAPI
+                  cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+                  certificate eAPI.crt key eAPI.key
+            !
         DC1_PE12:
           id: 2
           bgp_as: 65102
@@ -116,6 +121,11 @@ l3leaf:
             !
             vlan 111
               designated-forwarder election preference rule low
+            !
+            management security
+               ssl profile eAPI
+                  cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+                  certificate eAPI.crt key eAPI.key
             !
 
     POD_2:
@@ -153,6 +163,11 @@ l3leaf:
             vlan 113
               designated-forwarder election preference rule low
             !
+            management security
+               ssl profile eAPI
+                  cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+                  certificate eAPI.crt key eAPI.key
+            !
         DC1_PE22:
           id: 4
           bgp_as: 65104
@@ -181,6 +196,11 @@ l3leaf:
             !
             vlan 113
               designated-forwarder election preference rule low
+            !
+            management security
+               ssl profile eAPI
+                  cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+                  certificate eAPI.crt key eAPI.key
             !
 
 # Enable Route Target Membership Constraint Address Family on EVPN overlay BGP peerings

--- a/labs/evpn/avd_sym_sa_multihoming/group_vars/DC1_SPINES.yaml
+++ b/labs/evpn/avd_sym_sa_multihoming/group_vars/DC1_SPINES.yaml
@@ -1,1 +1,8 @@
 type: spine
+custom_structured_configuration_eos_cli: |-
+  !
+  management security
+     ssl profile eAPI
+        cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+        certificate eAPI.crt key eAPI.key
+  !

--- a/labs/evpn/avd_sym_sa_multihoming/topology.yaml
+++ b/labs/evpn/avd_sym_sa_multihoming/topology.yaml
@@ -4,7 +4,11 @@ topology:
   kinds:
     ceos:
       startup-config: ../../../ceos_lab_template/ceos.cfg.tpl
-      image: ceosimage:4.27.3F
+      image: ceosimage:4.29.0.2F
+      exec:
+        - sleep 10
+        - FastCli -p 15 -c 'security pki key generate rsa 4096 eAPI.key'
+        - FastCli -p 15 -c 'security pki certificate generate self-signed eAPI.crt key eAPI.key generate rsa 4096 validity 30000 parameters common-name eAPI'
     linux:
       image: alpine-host
   nodes:

--- a/labs/mpls_ldp_evpn/mpls_evpn_irb/Makefile
+++ b/labs/mpls_ldp_evpn/mpls_evpn_irb/Makefile
@@ -1,0 +1,21 @@
+.PHONY: help
+help: ## Display help message
+	@grep -E '^[0-9a-zA-Z_-]+\.*[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: deploy
+deploy: ## Complete AVD & cEOS-Lab Deployment
+	@echo -e "\n############### \e[1;30;42mStarting cEOS-Lab topology\e[0m ###############\n"
+	@sudo containerlab deploy -t topology.yaml
+	@echo -e "\n############### \e[1;30;42mGenerating and deploying switch configuration\e[0m ###############\n"
+	@ansible-playbook playbooks/fabric-deploy-config.yaml --flush-cache
+	@echo -e "\n############### \e[1;30;42mConfiguring client nodes\e[0m ###############\n"
+	@bash host_l3_config/l3_build.sh
+	@echo -e "\n############### \e[1;30;42mcEOS-Lab Topology\e[0m ###############\n"
+	@sudo containerlab inspect -t topology.yaml
+	@echo -e "\n############### \e[1;30;42mcEOS-Lab Deployment Complete\e[0m ###############\n"
+
+.PHONY: destroy
+destroy: ## Delete cEOS-Lab Deployment and AVD generated config and documentation
+	@echo -e "\n############### \e[1;30;42mWiping nodes and deleting AVD configuration\e[0m ###############\n"
+	@sudo containerlab destroy -t topology.yaml --cleanup
+	@rm -rf .topology.yml.bak config_backup/ snapshots/ reports/ documentation/devices/*.md intended/configs/*.cfg

--- a/labs/mpls_ldp_evpn/mpls_evpn_irb/intended/structured_configs/DC1_P1.yml
+++ b/labs/mpls_ldp_evpn/mpls_evpn_irb/intended/structured_configs/DC1_P1.yml
@@ -87,6 +87,7 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+  https_ssl_profile: eAPI
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
@@ -198,3 +199,10 @@ mpls:
   ldp:
     router_id: interface Loopback0
     shutdown: false
+eos_cli: |
+  !
+  management security
+     ssl profile eAPI
+        cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+        certificate eAPI.crt key eAPI.key
+  !

--- a/labs/mpls_ldp_evpn/mpls_evpn_irb/intended/structured_configs/DC1_P2.yml
+++ b/labs/mpls_ldp_evpn/mpls_evpn_irb/intended/structured_configs/DC1_P2.yml
@@ -87,6 +87,7 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+  https_ssl_profile: eAPI
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
@@ -198,3 +199,10 @@ mpls:
   ldp:
     router_id: interface Loopback0
     shutdown: false
+eos_cli: |
+  !
+  management security
+     ssl profile eAPI
+        cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+        certificate eAPI.crt key eAPI.key
+  !

--- a/labs/mpls_ldp_evpn/mpls_evpn_irb/intended/structured_configs/DC1_PE11.yml
+++ b/labs/mpls_ldp_evpn/mpls_evpn_irb/intended/structured_configs/DC1_PE11.yml
@@ -110,6 +110,7 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+  https_ssl_profile: eAPI
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
@@ -268,3 +269,10 @@ mpls:
   ldp:
     router_id: interface Loopback0
     shutdown: false
+eos_cli: |
+  !
+  management security
+     ssl profile eAPI
+        cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+        certificate eAPI.crt key eAPI.key
+  !

--- a/labs/mpls_ldp_evpn/mpls_evpn_irb/intended/structured_configs/DC1_PE12.yml
+++ b/labs/mpls_ldp_evpn/mpls_evpn_irb/intended/structured_configs/DC1_PE12.yml
@@ -110,6 +110,7 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+  https_ssl_profile: eAPI
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
@@ -268,3 +269,10 @@ mpls:
   ldp:
     router_id: interface Loopback0
     shutdown: false
+eos_cli: |
+  !
+  management security
+     ssl profile eAPI
+        cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+        certificate eAPI.crt key eAPI.key
+  !

--- a/labs/mpls_ldp_evpn/mpls_evpn_irb/intended/structured_configs/DC1_PE21.yml
+++ b/labs/mpls_ldp_evpn/mpls_evpn_irb/intended/structured_configs/DC1_PE21.yml
@@ -110,6 +110,7 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+  https_ssl_profile: eAPI
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
@@ -268,3 +269,10 @@ mpls:
   ldp:
     router_id: interface Loopback0
     shutdown: false
+eos_cli: |
+  !
+  management security
+     ssl profile eAPI
+        cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+        certificate eAPI.crt key eAPI.key
+  !

--- a/labs/mpls_ldp_evpn/mpls_evpn_irb/intended/structured_configs/DC1_PE22.yml
+++ b/labs/mpls_ldp_evpn/mpls_evpn_irb/intended/structured_configs/DC1_PE22.yml
@@ -110,6 +110,7 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+  https_ssl_profile: eAPI
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
@@ -268,3 +269,10 @@ mpls:
   ldp:
     router_id: interface Loopback0
     shutdown: false
+eos_cli: |
+  !
+  management security
+     ssl profile eAPI
+        cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+        certificate eAPI.crt key eAPI.key
+  !

--- a/labs/mpls_ldp_evpn/mpls_evpn_irb/topology.yaml
+++ b/labs/mpls_ldp_evpn/mpls_evpn_irb/topology.yaml
@@ -4,7 +4,11 @@ topology:
   kinds:
     ceos:
       startup-config: ../../../ceos_lab_template/ceos.cfg.tpl
-      image: ceosimage:4.27.3F
+      image: ceosimage:4.29.0.2F
+      exec:
+        - sleep 10
+        - FastCli -p 15 -c 'security pki key generate rsa 4096 eAPI.key'
+        - FastCli -p 15 -c 'security pki certificate generate self-signed eAPI.crt key eAPI.key generate rsa 4096 validity 30000 parameters common-name eAPI'
     linux:
       image: alpine-host
   nodes:

--- a/labs/mpls_ldp_evpn/mpls_ldp_l2evpn/Makefile
+++ b/labs/mpls_ldp_evpn/mpls_ldp_l2evpn/Makefile
@@ -1,0 +1,21 @@
+.PHONY: help
+help: ## Display help message
+	@grep -E '^[0-9a-zA-Z_-]+\.*[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: deploy
+deploy: ## Complete AVD & cEOS-Lab Deployment
+	@echo -e "\n############### \e[1;30;42mStarting cEOS-Lab topology\e[0m ###############\n"
+	@sudo containerlab deploy -t topology.yaml
+	@echo -e "\n############### \e[1;30;42mGenerating and deploying switch configuration\e[0m ###############\n"
+	@ansible-playbook playbooks/fabric-deploy-config.yaml --flush-cache
+	@echo -e "\n############### \e[1;30;42mConfiguring client nodes\e[0m ###############\n"
+	@bash host_l3_config/l3_build.sh
+	@echo -e "\n############### \e[1;30;42mcEOS-Lab Topology\e[0m ###############\n"
+	@sudo containerlab inspect -t topology.yaml
+	@echo -e "\n############### \e[1;30;42mcEOS-Lab Deployment Complete\e[0m ###############\n"
+
+.PHONY: destroy
+destroy: ## Delete cEOS-Lab Deployment and AVD generated config and documentation
+	@echo -e "\n############### \e[1;30;42mWiping nodes and deleting AVD configuration\e[0m ###############\n"
+	@sudo containerlab destroy -t topology.yaml --cleanup
+	@rm -rf .topology.yml.bak config_backup/ snapshots/ reports/ documentation/devices/*.md intended/configs/*.cfg

--- a/labs/mpls_ldp_evpn/mpls_ldp_l2evpn/intended/structured_configs/DC1_P1.yml
+++ b/labs/mpls_ldp_evpn/mpls_ldp_l2evpn/intended/structured_configs/DC1_P1.yml
@@ -87,6 +87,7 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+  https_ssl_profile: eAPI
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
@@ -198,3 +199,10 @@ mpls:
   ldp:
     router_id: interface Loopback0
     shutdown: false
+eos_cli: |
+  !
+  management security
+     ssl profile eAPI
+        cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+        certificate eAPI.crt key eAPI.key
+  !

--- a/labs/mpls_ldp_evpn/mpls_ldp_l2evpn/intended/structured_configs/DC1_P2.yml
+++ b/labs/mpls_ldp_evpn/mpls_ldp_l2evpn/intended/structured_configs/DC1_P2.yml
@@ -87,6 +87,7 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+  https_ssl_profile: eAPI
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
@@ -198,3 +199,10 @@ mpls:
   ldp:
     router_id: interface Loopback0
     shutdown: false
+eos_cli: |
+  !
+  management security
+     ssl profile eAPI
+        cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+        certificate eAPI.crt key eAPI.key
+  !

--- a/labs/mpls_ldp_evpn/mpls_ldp_l2evpn/intended/structured_configs/DC1_PE11.yml
+++ b/labs/mpls_ldp_evpn/mpls_ldp_l2evpn/intended/structured_configs/DC1_PE11.yml
@@ -102,6 +102,7 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+  https_ssl_profile: eAPI
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
@@ -243,3 +244,10 @@ mpls:
   ldp:
     router_id: interface Loopback0
     shutdown: false
+eos_cli: |
+  !
+  management security
+     ssl profile eAPI
+        cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+        certificate eAPI.crt key eAPI.key
+  !

--- a/labs/mpls_ldp_evpn/mpls_ldp_l2evpn/intended/structured_configs/DC1_PE12.yml
+++ b/labs/mpls_ldp_evpn/mpls_ldp_l2evpn/intended/structured_configs/DC1_PE12.yml
@@ -102,6 +102,7 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+  https_ssl_profile: eAPI
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
@@ -243,3 +244,10 @@ mpls:
   ldp:
     router_id: interface Loopback0
     shutdown: false
+eos_cli: |
+  !
+  management security
+     ssl profile eAPI
+        cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+        certificate eAPI.crt key eAPI.key
+  !

--- a/labs/mpls_ldp_evpn/mpls_ldp_l2evpn/intended/structured_configs/DC1_PE21.yml
+++ b/labs/mpls_ldp_evpn/mpls_ldp_l2evpn/intended/structured_configs/DC1_PE21.yml
@@ -102,6 +102,7 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+  https_ssl_profile: eAPI
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
@@ -243,3 +244,10 @@ mpls:
   ldp:
     router_id: interface Loopback0
     shutdown: false
+eos_cli: |
+  !
+  management security
+     ssl profile eAPI
+        cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+        certificate eAPI.crt key eAPI.key
+  !

--- a/labs/mpls_ldp_evpn/mpls_ldp_l2evpn/intended/structured_configs/DC1_PE22.yml
+++ b/labs/mpls_ldp_evpn/mpls_ldp_l2evpn/intended/structured_configs/DC1_PE22.yml
@@ -102,6 +102,7 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+  https_ssl_profile: eAPI
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
@@ -243,3 +244,10 @@ mpls:
   ldp:
     router_id: interface Loopback0
     shutdown: false
+eos_cli: |
+  !
+  management security
+     ssl profile eAPI
+        cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+        certificate eAPI.crt key eAPI.key
+  !

--- a/labs/mpls_ldp_evpn/mpls_ldp_l2evpn/topology.yaml
+++ b/labs/mpls_ldp_evpn/mpls_ldp_l2evpn/topology.yaml
@@ -4,7 +4,11 @@ topology:
   kinds:
     ceos:
       startup-config: ../../../ceos_lab_template/ceos.cfg.tpl
-      image: ceosimage:4.27.3F
+      image: ceosimage:4.29.0.2F
+      exec:
+        - sleep 10
+        - FastCli -p 15 -c 'security pki key generate rsa 4096 eAPI.key'
+        - FastCli -p 15 -c 'security pki certificate generate self-signed eAPI.crt key eAPI.key generate rsa 4096 validity 30000 parameters common-name eAPI'
     linux:
       image: alpine-host
   nodes:


### PR DESCRIPTION
Starting Python 3.10 the default SSL/TLS ciphers have been [updated](https://bugs.python.org/issue43998). Latest [`release`](https://github.com/arista-netdevops-community/avd-cEOS-Lab/releases) of this repository updates the cipher suite on EOS via a security profile applied to eAPI to be compatible with Python 3.10.

Updated the base `ceos.cfg.tpl` to include the SSL profile

```shell
  13   │ !
  14   │ management security
  15   │    ssl profile eAPI
  16   │       cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
  17   │       certificate eAPI.crt key eAPI.key
  18   │ !
  19   │ management api http-commands
  20   │    protocol https ssl profile eAPI
  21   │    no shutdown
  22   │    !
  23   │    vrf MGMT
  24   │       no shutdown
  25   │ !
```

Same security profile also added to AVD group_vars for each lab.

Added Makefile for quicker lab deployment and cleanup.

```shell
deploy                         Complete AVD & cEOS-Lab Deployment
destroy                        Delete cEOS-Lab Deployment and AVD generated config and documentation
help                           Display help message
```

Closes #10 